### PR TITLE
Improve drag-and-drop UI and restrict drop targets

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -56,7 +56,9 @@ audio { display: block; }
 }
 
 .target-zone {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
   background-color: rgba(126, 18, 169, 0.22);
   border: 3px dashed rgba(246, 180, 12, 0.526);
@@ -68,10 +70,9 @@ audio { display: block; }
 #target-zone-box {
   display: flex;
   flex-direction: row;
-  gap: 1.5em;
+  gap: 1em;
   margin-top: 3em;
 }
-
 
 
 .label {

--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
     <h2 class="hidden">Draggable Objects</h2>
 
       <div id="label-box">
-        <div class="label" data-trackref="Boxer" draggable="true"><img src="images/Boxer.png" alt="boxer alien" class="track-ref"></div>
-        <div class="label" data-trackref="Funky" draggable="true"><img src="images/funky.png" alt="funky alien" class="track-ref"></div>
-        <div class="label" data-trackref="Guitar" draggable="true"><img src="images/Guitar.png" alt="guitar alien" class="track-ref"></div>
-        <div class="label" data-trackref="Robot" draggable="true"><img src="images/Robot.png" alt="robot alien" class="track-ref"></div>
-        <div class="label" data-trackref="Upbeat" draggable="true"><img src="images/Upbeat.png" alt="upbeat alien" class="track-ref"></div>
+        <div class="label" data-trackref="Boxer" draggable="true"><img src="images/Boxer.png" alt="boxer alien"></div>
+        <div class="label" data-trackref="Funky" draggable="true"><img src="images/funky.png" alt="funky alien"></div>
+        <div class="label" data-trackref="Guitar" draggable="true"><img src="images/Guitar.png" alt="guitar alien"></div>
+        <div class="label" data-trackref="Robot" draggable="true"><img src="images/Robot.png" alt="robot alien"></div>
+        <div class="label" data-trackref="Upbeat" draggable="true"><img src="images/Upbeat.png" alt="upbeat alien"></div>
       </div>
 
       <div id="target-zone-box">

--- a/js/main.js
+++ b/js/main.js
@@ -57,8 +57,10 @@ function dragOver(event) {
 
 function drop(event) {
     event.preventDefault();
-    this.appendChild(currentDraggedElement);
-    currentDraggedElement = null;
+    if (this.children.length === 0) {
+        this.appendChild(currentDraggedElement);
+        currentDraggedElement = null;
+    }
 }
 
 //Event listeners


### PR DESCRIPTION
Updated .target-zone to use flexbox for better alignment and adjusted gap in #target-zone-box for improved layout. Removed unnecessary 'track-ref' class from label images in index.html. Modified drop logic in main.js to only allow dropping if the target zone is empty, preventing multiple items in a single target.